### PR TITLE
Update C.83 with swap for resource mgmt.

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -6428,7 +6428,7 @@ Providing a non-member `swap` function in the same namespace as your type for ca
 
 ##### Enforcement
 
-* (Simple) A class without virtual functions should have a `swap` member function declared.
+* A class managing a resource should have a `swap` member function declared.
 * (Simple) When a class has a `swap` member function, it should be declared `noexcept`.
 
 ### <a name="Rc-swap-fail"></a>C.84: A `swap` function must not fail

--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -6428,7 +6428,7 @@ Providing a non-member `swap` function in the same namespace as your type for ca
 
 ##### Enforcement
 
-* A class managing a resource should have a `swap` member function declared.
+* Non-trivially copyable value types should provide a member swap or a free swap overload.
 * (Simple) When a class has a `swap` member function, it should be declared `noexcept`.
 
 ### <a name="Rc-swap-fail"></a>C.84: A `swap` function must not fail


### PR DESCRIPTION
The swap is useful to implement assignments idiomatically (e.g. copy-swap idiom).

With the current enforcement, to non-virtual classes, very simple classes (e.g. `trivially_copyable`, a struct encapsulating an stl container) are suggested to have a swap. This suggestion can be argued wrong since for very simple classes copy-swap idiom is not efficient (the creation of a third object on assignment is not needed, which copy-swap does).